### PR TITLE
[USD-4] feat: 재생목록 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // NanoId
+    implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/uhsadong/ddtube/DdtubeApplication.java
+++ b/src/main/java/com/uhsadong/ddtube/DdtubeApplication.java
@@ -2,7 +2,9 @@ package com.uhsadong.ddtube;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DdtubeApplication {
 

--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -1,13 +1,18 @@
 package com.uhsadong.ddtube.domain.controller;
 
+import com.uhsadong.ddtube.domain.dto.request.CreatePlaylistRequestDTO;
+import com.uhsadong.ddtube.domain.service.PlaylistCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,18 +20,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/playlist")
 public class PlaylistController {
 
+    private final PlaylistCommandService playlistCommandService;
+
     @GetMapping("/{playlistId}")
     @Operation(summary = "재생목록 조회", description = "재생목록 조회 기능입니다.")
     public ResponseEntity<String> getPlaylist(
-        @PathVariable Long playlistId
+        @PathVariable Long playlistId,
+        @RequestParam(required = false) String pin
     ) {
         return ResponseEntity.ok("Hello, World!");
     }
 
     @PostMapping()
-    @Operation(summary = "재생목록 생성", description = "재생목록 생성 기능입니다.")
-    public ResponseEntity<String> createPlaylist() {
-        return ResponseEntity.ok("Hello, World!");
+    @Operation(summary = "재생목록 생성", description = "재생목록을 생성합니다. 생성하는 유저는 필수적으로 name과 password를 입력해야합니다.")
+    public ResponseEntity<String> createPlaylist(
+        @RequestBody @Valid CreatePlaylistRequestDTO createPlaylistRequestDTO
+    ) {
+        return ResponseEntity.ok(
+            playlistCommandService.createPlaylist(createPlaylistRequestDTO)
+        );
     }
 
     @DeleteMapping("/{playlistId}")

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreatePlaylistRequestDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreatePlaylistRequestDTO.java
@@ -1,8 +1,17 @@
 package com.uhsadong.ddtube.domain.dto.request;
 
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
+
 public record CreatePlaylistRequestDTO(
-    String title,
-    String description
+    @Length(min = 2, max = 20, message = "이름은 2자 이상 20자 이하여야 합니다.")
+    String userName, // 만든사람 닉네임
+    @Length(min = 2, max = 100, message = "비밀번호는 2자 이상 100자 이하여야 합니다.")
+    String userPassword, // 만든사람 비밀번호
+    @Pattern(regexp = "\\d{4}", message = "PIN은 4자리 숫자여야 합니다.")
+    String playlistPin, // 4자리 숫자
+    @Length(min = 1, max = 100, message = "재생목록 제목은 1자 이상 100자 이하여야 합니다.")
+    String playlistTitle // 재생목록 제목
 ) {
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreateUserRequestDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreateUserRequestDTO.java
@@ -1,0 +1,14 @@
+package com.uhsadong.ddtube.domain.dto.request;
+
+import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
+
+@Builder
+public record CreateUserRequestDTO(
+    @Length(min = 2, max = 20, message = "이름은 2자 이상 20자 이하여야 합니다.")
+    String name,
+    @Length(min = 2, max = 100, message = "비밀번호는 2자 이상 100자 이하여야 합니다.")
+    String password
+) {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
@@ -29,13 +29,18 @@ public class Playlist {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false, length = 5, unique = true)
     @Length(min = 5, max = 5)
     private String code; // 5자리 AlphaNumeric
+
+    @Column(nullable = false, length = 100)
+    @Length(min = 1, max = 100)
+    private String title;
     @Length(min = 4, max = 4)
     @Column(nullable = false)
     @Pattern(regexp = "\\d{4}", message = "PIN must be a 4-digit number")
     private String pin; // 4자리 숫자
+
     @Column(nullable = false)
     private LocalDate willDeleteAt;
 
@@ -43,5 +48,14 @@ public class Playlist {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+
+    public static Playlist toEntity(String code, String title, String pin, LocalDate willDeleteAt) {
+        return Playlist.builder()
+            .code(code)
+            .title(title)
+            .pin(pin)
+            .willDeleteAt(willDeleteAt)
+            .build();
+    }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/User.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/User.java
@@ -32,6 +32,10 @@ public class User {
     @ManyToOne(fetch = FetchType.LAZY)
     private Playlist playlist;
 
+    @Column(nullable = false, length = 5, unique = true)
+    @Length(min = 5, max = 5)
+    private String code; // 5자리 AlphaNumeric
+
     @Length(min=2, max=20)
     @Column(nullable = false, length = 20)
     private String name;
@@ -45,4 +49,14 @@ public class User {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+
+    public static User toEntity(Playlist playlist, String code, String name, String password, boolean isAdmin) {
+        return User.builder()
+            .playlist(playlist)
+            .code(code)
+            .name(name)
+            .password(password)
+            .isAdmin(isAdmin)
+            .build();
+    }
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
@@ -1,0 +1,8 @@
+package com.uhsadong.ddtube.domain.repository;
+
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/UserRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.uhsadong.ddtube.domain.repository;
+
+import com.uhsadong.ddtube.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/VideoRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/VideoRepository.java
@@ -1,0 +1,8 @@
+package com.uhsadong.ddtube.domain.repository;
+
+import com.uhsadong.ddtube.domain.entity.Video;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoRepository extends JpaRepository<Video, Long> {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -1,0 +1,45 @@
+package com.uhsadong.ddtube.domain.service;
+
+import com.uhsadong.ddtube.domain.dto.request.CreatePlaylistRequestDTO;
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.entity.User;
+import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
+import com.uhsadong.ddtube.global.util.IdGenerator;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistCommandService {
+
+    @Value("${ddtube.playlist.code_length}")
+    private Integer PLAYLIST_CODE_LENGTH;
+
+    private final PlaylistRepository playlistRepository;
+    private final UserCommandService userCommandService;
+
+    /**
+     * 재생목록을 생성함 + 동시에 재생목록을 생성한 사람의 정보도 생성함
+     *
+     * @param requestDTO
+     * @return
+     */
+    public String createPlaylist(CreatePlaylistRequestDTO requestDTO) {
+        String code = IdGenerator.generateShortId(PLAYLIST_CODE_LENGTH);
+        LocalDate willDeleteAt = LocalDate.now().plusDays(7);
+        Playlist playlist = playlistRepository.save(
+            Playlist.toEntity(
+                code, requestDTO.playlistTitle(), requestDTO.playlistPin(), willDeleteAt
+            )
+        );
+
+        User user = userCommandService.createPlaylistCreator(
+            playlist, requestDTO.userName(), requestDTO.userPassword()
+        );
+
+        return playlist.getCode();
+    }
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/UserCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/UserCommandService.java
@@ -1,0 +1,26 @@
+package com.uhsadong.ddtube.domain.service;
+
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.entity.User;
+import com.uhsadong.ddtube.domain.repository.UserRepository;
+import com.uhsadong.ddtube.global.util.IdGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandService {
+
+    @Value("${ddtube.user.code_length}")
+    private Integer USER_CODE_LENGTH;
+
+    private final UserRepository userRepository;
+
+    public User createPlaylistCreator(Playlist playlist, String name, String password) {
+        String code = IdGenerator.generateShortId(USER_CODE_LENGTH);
+        return userRepository.save(
+            User.toEntity(playlist, code, name, password, true)
+        );
+    }
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
@@ -1,0 +1,12 @@
+package com.uhsadong.ddtube.domain.service;
+
+import com.uhsadong.ddtube.domain.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VideoCommandService {
+    private final VideoRepository videoRepository;
+
+}

--- a/src/main/java/com/uhsadong/ddtube/global/config/SecurityConfig.java
+++ b/src/main/java/com/uhsadong/ddtube/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         return httpSecurity
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
+                .requestMatchers("/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
                 .permitAll()
                 .requestMatchers("/api/public/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/uhsadong/ddtube/global/util/IdGenerator.java
+++ b/src/main/java/com/uhsadong/ddtube/global/util/IdGenerator.java
@@ -1,0 +1,18 @@
+package com.uhsadong.ddtube.global.util;
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdGenerator {
+
+    // TODO: Random은 정말 Random인가?
+    private static final Random random = new Random();
+    private static final char[] ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+
+    public static String generateShortId(int length) {
+        return NanoIdUtils.randomNanoId(random, ALPHABET, length);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: ddtube
+ddtube:
+  playlist:
+    code_length: 5
+  user:
+    code_length: 5


### PR DESCRIPTION
# 기능
- 재생목록을 생성합니다. 생성과 동시에 관리하는 유저도 생성합니다.
- 그렇기 때문에 재생목록의 정보과, 유저 정보를 모두 입력해주어야 합니다.

# 테스트
![재생목록 생성 기능](https://github.com/user-attachments/assets/d3b8ef85-c327-4300-bf5f-88c69a9d2a0e)
