### PR TITLE
[USD-9] feat: 재생목록에 영상 추가 기능 구현

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -32,7 +32,7 @@ public class PlaylistController {
     }
 
     @PostMapping()
-    @Operation(summary = "재생목록 생성", description = "재생목록을 생성합니다. 생성하는 유저는 필수적으로 name과 password를 입력해야합니다.")
+    @Operation(summary = "[0326] 재생목록 생성", description = "재생목록을 생성합니다. 생성하는 유저는 필수적으로 name과 password를 입력해야합니다.")
     public ResponseEntity<String> createPlaylist(
         @RequestBody @Valid CreatePlaylistRequestDTO createPlaylistRequestDTO
     ) {

--- a/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
@@ -1,11 +1,15 @@
 package com.uhsadong.ddtube.domain.controller;
 
+import com.uhsadong.ddtube.domain.dto.request.AddVideoToPlaylistRequestDTO;
+import com.uhsadong.ddtube.domain.service.VideoCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,21 +18,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/video")
 public class VideoController {
 
-    @PostMapping("/{playlistId}")
+    private final VideoCommandService videoCommandService;
+
+    @PostMapping("/{playlistCode}")
     @Operation(summary = "재생목록에 영상 추가", description = "재생목록에 영상을 추가하는 기능입니다.")
     public ResponseEntity<String> addVideoToPlaylist(
-        @PathVariable Long playlistId
+        @PathVariable String playlistCode,
+        @RequestBody @Valid AddVideoToPlaylistRequestDTO addVideoToPlaylistRequestDTO
     ) {
-        return ResponseEntity.ok(Long.toString(playlistId));
+        videoCommandService.addVideoToPlaylist(playlistCode, addVideoToPlaylistRequestDTO);
+        return ResponseEntity.ok("추가 완료");
     }
 
-    @DeleteMapping("/{playlistId}/{videoId}")
+    @DeleteMapping("/{playlistCode}/{videoId}")
     @Operation(summary = "재생목록에서 영상 제거", description = "재생목록에 영상을 제거하는 기능입니다.")
     public ResponseEntity<String> deleteVideoInPlaylist(
-        @PathVariable Long playlistId,
+        @PathVariable Long playlistCode,
         @PathVariable Long videoId
     ) {
-        return ResponseEntity.ok(Long.toString(playlistId));
+        return ResponseEntity.ok(Long.toString(playlistCode));
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/YoutubeOEmbedDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/YoutubeOEmbedDTO.java
@@ -1,0 +1,19 @@
+package com.uhsadong.ddtube.domain.dto;
+
+public record YoutubeOEmbedDTO(
+    String title,
+    String author_name,
+    String author_url,
+    String type,
+    int height,
+    int width,
+    String version,
+    String provider_name,
+    String provider_url,
+    String thumbnail_height,
+    String thumbnail_width,
+    String thumbnail_url,
+    String html
+) {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/request/AddVideoToPlaylistRequestDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/request/AddVideoToPlaylistRequestDTO.java
@@ -1,0 +1,10 @@
+package com.uhsadong.ddtube.domain.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+public record AddVideoToPlaylistRequestDTO(
+    @Length(min = 2, max = 300, message = "주소는 최대 300자까지 입력이 가능합니다.")
+    String videoUrl
+) {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreatePlaylistRequestDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/request/CreatePlaylistRequestDTO.java
@@ -1,6 +1,5 @@
 package com.uhsadong.ddtube.domain.dto.request;
 
-import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 public record CreatePlaylistRequestDTO(
@@ -8,8 +7,6 @@ public record CreatePlaylistRequestDTO(
     String userName, // 만든사람 닉네임
     @Length(min = 2, max = 100, message = "비밀번호는 2자 이상 100자 이하여야 합니다.")
     String userPassword, // 만든사람 비밀번호
-    @Pattern(regexp = "\\d{4}", message = "PIN은 4자리 숫자여야 합니다.")
-    String playlistPin, // 4자리 숫자
     @Length(min = 1, max = 100, message = "재생목록 제목은 1자 이상 100자 이하여야 합니다.")
     String playlistTitle // 재생목록 제목
 ) {

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
@@ -6,8 +6,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.Pattern;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,10 +34,6 @@ public class Playlist {
     @Column(nullable = false, length = 100)
     @Length(min = 1, max = 100)
     private String title;
-    @Length(min = 4, max = 4)
-    @Column(nullable = false)
-    @Pattern(regexp = "\\d{4}", message = "PIN must be a 4-digit number")
-    private String pin; // 4자리 숫자
 
     @Column(nullable = false)
     private LocalDateTime willDeleteAt;
@@ -49,11 +43,10 @@ public class Playlist {
     private LocalDateTime createdAt;
 
 
-    public static Playlist toEntity(String code, String title, String pin, LocalDateTime willDeleteAt) {
+    public static Playlist toEntity(String code, String title, LocalDateTime willDeleteAt) {
         return Playlist.builder()
             .code(code)
             .title(title)
-            .pin(pin)
             .willDeleteAt(willDeleteAt)
             .build();
     }

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/Video.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/Video.java
@@ -1,5 +1,6 @@
 package com.uhsadong.ddtube.domain.entity;
 
+import com.uhsadong.ddtube.domain.dto.YoutubeOEmbedDTO;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -36,13 +37,41 @@ public class Video {
     @Length(max=255)
     @Column(nullable = false, length = 255)
     private String title;
+    @Length(max=100)
+    @Column(nullable = false, length = 100)
+    private String author_name;
     @Length(max=1000)
     @Column(nullable = false, length = 1000)
     private String url;
-    @Column(nullable = false)
-    private LocalTime duration;
+    private Integer height;
+    private Integer width;
+    @Length(max=1000)
+    @Column(nullable = false, length = 1000)
+    private String thumbnail_url;
+    private Integer thumbnail_height;
+    private Integer thumbnail_width;
+
+
+
+    // 해당 정보는 어디서 받아올 수 있을지 체크해야함
+//    @Column(nullable = false)
+//    private LocalTime duration;
 
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    public static Video toEntity(Playlist playlist, String videoUrl, YoutubeOEmbedDTO youtubeInfo) {
+        return Video.builder()
+            .playlist(playlist)
+            .title(youtubeInfo.title())
+            .author_name(youtubeInfo.author_name())
+            .url(videoUrl)
+            .height(youtubeInfo.height())
+            .width(youtubeInfo.width())
+            .thumbnail_url(youtubeInfo.thumbnail_url())
+            .thumbnail_height(Integer.valueOf(youtubeInfo.thumbnail_height()))
+            .thumbnail_width(Integer.valueOf(youtubeInfo.thumbnail_width()))
+            .build();
+    }
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
@@ -1,8 +1,9 @@
 package com.uhsadong.ddtube.domain.repository;
 
 import com.uhsadong.ddtube.domain.entity.Playlist;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
-
+    Optional<Playlist> findFirstByCode(String code);
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -6,7 +6,6 @@ import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
 import com.uhsadong.ddtube.global.util.IdGenerator;
 import jakarta.transaction.Transactional;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,13 +15,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaylistCommandService {
 
+    private final PlaylistRepository playlistRepository;
+    private final UserCommandService userCommandService;
     @Value("${ddtube.playlist.code_length}")
     private Integer PLAYLIST_CODE_LENGTH;
     @Value("${ddtube.playlist.delete_hours}")
     private Integer PLAYLIST_DELETE_HOURS;
-
-    private final PlaylistRepository playlistRepository;
-    private final UserCommandService userCommandService;
 
     /**
      * 재생목록을 생성함 + 동시에 재생목록을 생성한 사람의 정보도 생성함
@@ -36,7 +34,7 @@ public class PlaylistCommandService {
         LocalDateTime willDeleteAt = LocalDateTime.now().plusHours(PLAYLIST_DELETE_HOURS);
         Playlist playlist = playlistRepository.save(
             Playlist.toEntity(
-                code, requestDTO.playlistTitle(), requestDTO.playlistPin(), willDeleteAt
+                code, requestDTO.playlistTitle(), willDeleteAt
             )
         );
 

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -1,0 +1,19 @@
+package com.uhsadong.ddtube.domain.service;
+
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistQueryService {
+
+    private final PlaylistRepository playlistRepository;
+
+    public Playlist getPlaylistByCodeOrThrow(String code) {
+        return playlistRepository.findFirstByCode(code)
+            .orElseThrow(IllegalArgumentException::new);
+    }
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -13,7 +13,7 @@ public class PlaylistQueryService {
 
     public Playlist getPlaylistByCodeOrThrow(String code) {
         return playlistRepository.findFirstByCode(code)
-            .orElseThrow(IllegalArgumentException::new);
+            .orElseThrow(() -> new IllegalArgumentException("코드가 '" + code + "'인 플레이리스트를 찾을 수 없습니다"));
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
@@ -1,12 +1,30 @@
 package com.uhsadong.ddtube.domain.service;
 
+import com.uhsadong.ddtube.domain.dto.YoutubeOEmbedDTO;
+import com.uhsadong.ddtube.domain.dto.request.AddVideoToPlaylistRequestDTO;
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.entity.Video;
 import com.uhsadong.ddtube.domain.repository.VideoRepository;
+import com.uhsadong.ddtube.global.util.YoutubeOEmbed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class VideoCommandService {
+
     private final VideoRepository videoRepository;
+    private final PlaylistQueryService playlistQueryService;
+
+    public void addVideoToPlaylist(
+        String playlistCode, AddVideoToPlaylistRequestDTO requestDTO) {
+
+        Playlist playlist = playlistQueryService.getPlaylistByCodeOrThrow(playlistCode);
+
+        YoutubeOEmbedDTO youtubeOEmbedDTO = YoutubeOEmbed.getVideoInfo(requestDTO.videoUrl());
+        videoRepository.save(
+            Video.toEntity(playlist, requestDTO.videoUrl(), youtubeOEmbedDTO)
+        );
+    }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
@@ -6,6 +6,7 @@ import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.Video;
 import com.uhsadong.ddtube.domain.repository.VideoRepository;
 import com.uhsadong.ddtube.global.util.YoutubeOEmbed;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ public class VideoCommandService {
     private final VideoRepository videoRepository;
     private final PlaylistQueryService playlistQueryService;
 
+    @Transactional
     public void addVideoToPlaylist(
         String playlistCode, AddVideoToPlaylistRequestDTO requestDTO) {
 

--- a/src/main/java/com/uhsadong/ddtube/global/util/YoutubeOEmbed.java
+++ b/src/main/java/com/uhsadong/ddtube/global/util/YoutubeOEmbed.java
@@ -1,0 +1,25 @@
+package com.uhsadong.ddtube.global.util;
+
+import com.uhsadong.ddtube.domain.dto.YoutubeOEmbedDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+public class YoutubeOEmbed {
+
+    private static final String OEMBED_URL = "https://www.youtube.com/oembed";
+
+    public static YoutubeOEmbedDTO getVideoInfo(String videoUrl) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+            .fromHttpUrl(OEMBED_URL)
+            .queryParam("url", videoUrl)
+            .queryParam("format", "json");
+
+        String uri = builder.build(false).toUriString();
+
+        return restTemplate.getForObject(uri, YoutubeOEmbedDTO.class);
+    }
+}


### PR DESCRIPTION
# 기능
- 재생목록에 영상을 추가하는 기능을 구현했습니다
- 유튜브 동영상 정보를 가져오기 위해 OEmbed 링크를 사용했습니다.

# 구현 결과
![재생목록에 영상 추가 기능](https://github.com/user-attachments/assets/85dbcc93-aa9e-4b73-b617-c7566bcdcea8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 재생목록 생성 시 식별자가 포함되어 API 정보가 보다 명확해졌습니다.
  - 동영상 추가/삭제 요청에 대해 검증 강화와 응답 메시지 개선이 이루어졌습니다.
  - 유튜브 영상 정보 조회 기능이 추가되어, 더 풍부한 영상 메타데이터를 제공합니다.
  
- **Refactor**
  - 재생목록과 동영상 관련 식별자 방식을 업데이트하여 일관성과 안정성이 향상되었습니다.
  - 관련 서비스와 유틸리티 도입으로 내부 처리 흐름이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->