### PR TITLE
USD-108 잘못된 PL인지 체크하는 API 구현

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -3,6 +3,7 @@ package com.uhsadong.ddtube.domain.controller;
 import com.uhsadong.ddtube.domain.dto.request.CreatePlaylistRequestDTO;
 import com.uhsadong.ddtube.domain.dto.response.CreatePlaylistResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.PlaylistDetailResponseDTO;
+import com.uhsadong.ddtube.domain.dto.response.PlaylistHealthResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.PlaylistMetaResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.PlaylistPublicMetaResponseDTO;
 import com.uhsadong.ddtube.domain.entity.User;
@@ -14,6 +15,7 @@ import com.uhsadong.ddtube.global.util.S3Util;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,6 +36,16 @@ public class PlaylistController {
     private final PlaylistCommandService playlistCommandService;
     private final S3Util s3Util;
     private final PlaylistQueryService playlistQueryService;
+
+    @GetMapping("/{playlistCode}/health")
+    @Operation(summary = "재생목록 상태 확인", description = "재생목록 상태 확인 기능입니다.")
+    public ResponseEntity<ApiResponse<PlaylistHealthResponseDTO>> checkPlaylistHealth(
+        @PathVariable String playlistCode
+    ) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            playlistQueryService.checkPlaylistHealth(playlistCode)
+        ));
+    }
 
     @GetMapping("/{playlistCode}")
     @Operation(summary = "재생목록 조회", description = "재생목록 조회 기능입니다.")

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/response/PlaylistHealthResponseDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/response/PlaylistHealthResponseDTO.java
@@ -1,0 +1,12 @@
+package com.uhsadong.ddtube.domain.dto.response;
+
+import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
+import lombok.Builder;
+
+@Builder
+public record PlaylistHealthResponseDTO(
+    PlaylistHealth health,
+    String playlistCode
+) {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/Playlist.java
@@ -50,7 +50,7 @@ public class Playlist {
     private String thumbnailUrl;
 
     @Column(nullable = false)
-    private LocalDateTime willDeleteAt;
+    private LocalDateTime lastLoginAt;
 
     @CreatedDate
     @Column(updatable = false)
@@ -62,13 +62,13 @@ public class Playlist {
     private Video nowPlayVideo;
 
 
-    public static Playlist toEntity(String code, String title, String description, String thumbnailUrl ,LocalDateTime willDeleteAt) {
+    public static Playlist toEntity(String code, String title, String description, String thumbnailUrl ,LocalDateTime lastLoginAt) {
         return Playlist.builder()
             .code(code)
             .title(title)
             .description(description)
             .thumbnailUrl(thumbnailUrl)
-            .willDeleteAt(willDeleteAt)
+            .lastLoginAt(lastLoginAt)
             .build();
     }
 

--- a/src/main/java/com/uhsadong/ddtube/domain/enums/PlaylistHealth.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/enums/PlaylistHealth.java
@@ -1,0 +1,8 @@
+package com.uhsadong.ddtube.domain.enums;
+
+public enum PlaylistHealth {
+    ACTIVE,
+    INACTIVE,
+    NOT_EXIST;
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -30,8 +30,8 @@ public class PlaylistCommandService {
 
     @Value("${ddtube.playlist.code_length}")
     private Integer PLAYLIST_CODE_LENGTH;
-    @Value("${ddtube.playlist.delete_hours}")
-    private Integer PLAYLIST_DELETE_HOURS;
+    @Value("${ddtube.playlist.delete_days}")
+    private Integer PLAYLIST_DELETE_DAYS;
 
     @Value("${aws.s3.default-thumbneil-url}")
     private String defaultThumbnailUrl;
@@ -44,7 +44,7 @@ public class PlaylistCommandService {
         CreatePlaylistRequestDTO requestDTO
     ) {
         String code = IdGenerator.generateShortId(PLAYLIST_CODE_LENGTH);
-        LocalDateTime willDeleteAt = LocalDateTime.now().plusHours(PLAYLIST_DELETE_HOURS);
+        LocalDateTime lastLoginAt = LocalDateTime.now().plusDays(PLAYLIST_DELETE_DAYS);
 
         if (!(s3Util.isS3Url(requestDTO.thumbnailUrl()) || requestDTO.thumbnailUrl().isEmpty())) {
             throw new GeneralException(ErrorStatus._INVALID_THUMBNAIL_URL);
@@ -54,7 +54,7 @@ public class PlaylistCommandService {
 
         Playlist playlist = playlistRepository.save(
             Playlist.toEntity(code, requestDTO.playlistTitle(), requestDTO.playlistDescription(),
-                thumbnailUrl, willDeleteAt)
+                thumbnailUrl, lastLoginAt)
         );
 
         String accessToken = userCommandService.createPlaylistCreator(

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -1,18 +1,23 @@
 package com.uhsadong.ddtube.domain.service;
 
 import com.uhsadong.ddtube.domain.dto.response.PlaylistDetailResponseDTO;
+import com.uhsadong.ddtube.domain.dto.response.PlaylistHealthResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.PlaylistMetaResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.PlaylistPublicMetaResponseDTO;
 import com.uhsadong.ddtube.domain.dto.response.VideoDetailResponseDTO;
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
+import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
 import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
-import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,11 +27,19 @@ public class PlaylistQueryService {
     private final UserQueryService userQueryService;
     private final VideoQueryService videoQueryService;
 
+    @Value("${ddtube.playlist.delete_days}")
+    private Integer PLAYLIST_DELETE_DAYS;
+
     public Playlist getPlaylistByCodeOrThrow(String code) {
         return playlistRepository.findFirstByCode(code)
             .orElseThrow(() -> new GeneralException(ErrorStatus._PLAYLIST_NOT_FOUND));
     }
 
+    public Optional<Playlist> getPlaylistByCodeOptional(String code) {
+        return playlistRepository.findFirstByCode(code);
+    }
+
+    @Transactional(readOnly = true)
     public PlaylistPublicMetaResponseDTO getPlaylistPublicMetaInformation(String playlistCode) {
         Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
         return PlaylistPublicMetaResponseDTO.builder()
@@ -36,6 +49,7 @@ public class PlaylistQueryService {
             .build();
     }
 
+    @Transactional(readOnly = true)
     public PlaylistMetaResponseDTO getPlaylistMetaInformation(User user, String playlistCode) {
         Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
@@ -61,7 +75,7 @@ public class PlaylistQueryService {
             .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PlaylistDetailResponseDTO getPlaylistDetail(User user, String playlistCode) {
         Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
@@ -79,6 +93,37 @@ public class PlaylistQueryService {
             .title(playlist.getTitle())
             .nowPlayingVideoCode(nowPlayingVideoCode)
             .videoList(videoResponseList)
+            .build();
+    }
+
+    @Transactional(readOnly = true)
+    public PlaylistHealthResponseDTO checkPlaylistHealth(String playlistCode) {
+        Optional<Playlist> playlistOptional = getPlaylistByCodeOptional(playlistCode);
+
+        // 플레이리스트가 존재하지 않는 경우
+        if (playlistOptional.isEmpty()) {
+            return PlaylistHealthResponseDTO.builder()
+                .health(PlaylistHealth.NOT_EXIST)
+                .playlistCode(playlistCode)
+                .build();
+        }
+
+        // 플레이리스트가 존재하는 경우
+        Playlist playlist = playlistOptional.get();
+        PlaylistHealth health;
+
+        // 삭제 기준일을 지난 경우 INACTIVE 상태
+        if (playlist.getLastLoginAt().plusDays(PLAYLIST_DELETE_DAYS)
+            .isBefore(LocalDateTime.now())) {
+            health = PlaylistHealth.INACTIVE;
+        } else {
+            // 그 외의 경우 ACTIVE 상태
+            health = PlaylistHealth.ACTIVE;
+        }
+
+        return PlaylistHealthResponseDTO.builder()
+            .health(health)
+            .playlistCode(playlistCode)
             .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ logging:
 ddtube:
   playlist:
     code_length: 5
-    delete_hours: 6
+    delete_days: 1 #  플레이이스트 활성화 1일 유지
     priority_step: 100_000_000_000_000
   user:
     code_length: 5


### PR DESCRIPTION
- 현재 조회하는 플레이이스트가 잘못된 플레이리스트인지 확인하는 API를 구현했습니다.
- 상태값은 총 3가지로, ACTIVE, INACTIVE, NOT_EXIST 입니다.
- ACTIVE - 활성화되었으며 사용할 수 있는 상태
- INACTIVE - 활성화되었지만, 터진 상태
- NOT_EXIST - 존재하지 않는 플레이리스트

현재는 NOT_EXIST만 판단해주시면 되고, INACTIVE 여부는 따로 내부 로직을 수정해야하여 다음 PR에 반영할게요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 재생목록의 상태를 확인할 수 있는 건강 상태 조회 API가 추가되었습니다.

- **버그 수정**
  - 재생목록의 활성 기간 설정이 시간 단위에서 일 단위로 변경되었습니다.

- **기타**
  - 재생목록 관련 일부 필드 및 명칭이 변경되었습니다(예: 마지막 로그인 시각 등).
  - 재생목록 상태를 나타내는 값이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->