### PR TITLE
USD-107 SSE 연결이 끊기고, 플레이리스트 Timeout 24시간으로 처리하도록 처리

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -15,7 +15,6 @@ import com.uhsadong.ddtube.global.util.S3Util;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
@@ -14,9 +14,18 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
     /**
      * 입력된 모든 플레이리스트의 마지막 로그인 시간을 업데이트합니다.
+     * Deprecated: 이 메서드는 사용되지 않으므로 삭제할 예정입니다.
      */
     @Modifying
     @Query("UPDATE Playlist p SET p.lastLoginAt = :lastLoginAt WHERE p.code IN :playlistCodes")
     int updateLastLoginAtByPlaylistCodeIn(@Param("playlistCodes") Set<String> playlistCodes,
+        @Param("lastLoginAt") LocalDateTime lastLoginAt);
+
+    /**
+     * 플레이리스트 코드에 해당하는 플레이리스트의 마지막 로그인 시간을 업데이트합니다.
+     */
+    @Modifying
+    @Query("UPDATE Playlist p SET p.lastLoginAt = :lastLoginAt WHERE p.code = :playlistCode")
+    void updateLastLoginAtByPlaylistCode(@Param("playlistCode") String playlistCode,
         @Param("lastLoginAt") LocalDateTime lastLoginAt);
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/PlaylistRepository.java
@@ -1,9 +1,22 @@
 package com.uhsadong.ddtube.domain.repository;
 
 import com.uhsadong.ddtube.domain.entity.Playlist;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     Optional<Playlist> findFirstByCode(String code);
+
+    /**
+     * 입력된 모든 플레이리스트의 마지막 로그인 시간을 업데이트합니다.
+     */
+    @Modifying
+    @Query("UPDATE Playlist p SET p.lastLoginAt = :lastLoginAt WHERE p.code IN :playlistCodes")
+    int updateLastLoginAtByPlaylistCodeIn(@Param("playlistCodes") Set<String> playlistCodes,
+        @Param("lastLoginAt") LocalDateTime lastLoginAt);
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/repositoryservice/PlaylistRepositoryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repositoryservice/PlaylistRepositoryService.java
@@ -1,0 +1,41 @@
+package com.uhsadong.ddtube.domain.repositoryservice;
+
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
+import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
+import com.uhsadong.ddtube.global.response.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistRepositoryService {
+
+    private final PlaylistRepository playlistRepository;
+
+    public Playlist save(Playlist playlist) {
+        return playlistRepository.save(playlist);
+    }
+
+    @Transactional
+    public void updateLastLoginAtToNowByPlaylistCode(String playlistCode) {
+        playlistRepository.updateLastLoginAtByPlaylistCode(playlistCode,
+            LocalDateTime.now());
+    }
+
+    public Optional<Playlist> findByCodeOptional(String code) {
+        return playlistRepository.findFirstByCode(code);
+    }
+
+    public Playlist findByCodeOrThrow(String playlistCode) {
+        return playlistRepository.findFirstByCode(playlistCode)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._PLAYLIST_NOT_FOUND));
+    }
+
+    public void delete(Playlist playlist) {
+        playlistRepository.delete(playlist);
+    }
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -5,7 +5,7 @@ import com.uhsadong.ddtube.domain.dto.response.CreatePlaylistResponseDTO;
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.entity.Video;
-import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
+import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
 import com.uhsadong.ddtube.global.sse.SseService;
@@ -13,7 +13,6 @@ import com.uhsadong.ddtube.global.util.IdGenerator;
 import com.uhsadong.ddtube.global.util.S3Util;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,12 +21,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaylistCommandService {
 
-    private final PlaylistRepository playlistRepository;
     private final UserCommandService userCommandService;
     private final S3Util s3Util;
     private final UserQueryService userQueryService;
     private final VideoQueryService videoQueryService;
     private final SseService sseService;
+    private final PlaylistRepositoryService playlistRepositoryService;
 
     @Value("${ddtube.playlist.code_length}")
     private Integer PLAYLIST_CODE_LENGTH;
@@ -51,7 +50,7 @@ public class PlaylistCommandService {
         String thumbnailUrl = requestDTO.thumbnailUrl().isEmpty()
             ? defaultThumbnailUrl : requestDTO.thumbnailUrl();
 
-        Playlist playlist = playlistRepository.save(
+        Playlist playlist = playlistRepositoryService.save(
             Playlist.toEntity(code, requestDTO.playlistTitle(), requestDTO.playlistDescription(),
                 thumbnailUrl, lastLoginAt)
         );
@@ -68,20 +67,18 @@ public class PlaylistCommandService {
 
     @Transactional
     public void deletePlaylist(User user, String playlistCode) {
-        Playlist playlist = playlistRepository.findFirstByCode(playlistCode)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._PLAYLIST_NOT_FOUND));
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
         if (!user.isAdmin()) {
             throw new GeneralException(ErrorStatus._PLAYLIST_DELETE_PERMISSION_DENIED);
         }
-        playlistRepository.delete(playlist);
+        playlistRepositoryService.delete(playlist);
     }
 
     @Transactional
     public void setNowPlayingVideo(User user, String playlistCode, String videoCode,
         Boolean autoPlay) {
-        Playlist playlist = playlistRepository.findFirstByCode(playlistCode)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._PLAYLIST_NOT_FOUND));
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
         Video video = videoQueryService.getVideoByCodeOrThrow(videoCode);
         if (playlist.getNowPlayVideo() != null && video.getId()
@@ -94,13 +91,6 @@ public class PlaylistCommandService {
         playlist.setNowPlayVideo(video);
 
         sseService.sendNowPlayingVideoEventToClients(playlistCode, video, user.getName(), autoPlay);
-
-    }
-
-    @Transactional
-    public int updatePlaylistLastLoginAt(Set<String> playlistCodeSet) {
-        return playlistRepository.updateLastLoginAtByPlaylistCodeIn(playlistCodeSet,
-            LocalDateTime.now());
 
     }
 

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -112,7 +112,7 @@ public class PlaylistQueryService {
         Playlist playlist = playlistOptional.get();
         PlaylistHealth health;
 
-        // 삭제 기준일을 지난 경우 INACTIVE 상태
+        // 마지막으로 활성화된 시간 기준으로 PLAYLIST_DELETE_DAYS가 지났으면 INACTIVE 상태
         if (playlist.getLastLoginAt().plusDays(PLAYLIST_DELETE_DAYS)
             .isBefore(LocalDateTime.now())) {
             health = PlaylistHealth.INACTIVE;

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -8,7 +8,7 @@ import com.uhsadong.ddtube.domain.dto.response.VideoDetailResponseDTO;
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
-import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
+import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
 import java.time.LocalDateTime;
@@ -23,25 +23,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlaylistQueryService {
 
-    private final PlaylistRepository playlistRepository;
+    private final PlaylistRepositoryService playlistRepositoryService;
     private final UserQueryService userQueryService;
     private final VideoQueryService videoQueryService;
 
     @Value("${ddtube.playlist.delete_days}")
     private Integer PLAYLIST_DELETE_DAYS;
 
-    public Playlist getPlaylistByCodeOrThrow(String code) {
-        return playlistRepository.findFirstByCode(code)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._PLAYLIST_NOT_FOUND));
-    }
-
-    public Optional<Playlist> getPlaylistByCodeOptional(String code) {
-        return playlistRepository.findFirstByCode(code);
-    }
-
     @Transactional(readOnly = true)
     public PlaylistPublicMetaResponseDTO getPlaylistPublicMetaInformation(String playlistCode) {
-        Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         return PlaylistPublicMetaResponseDTO.builder()
             .title(playlist.getTitle())
             .thumbnailUrl(playlist.getThumbnailUrl())
@@ -51,7 +42,7 @@ public class PlaylistQueryService {
 
     @Transactional(readOnly = true)
     public PlaylistMetaResponseDTO getPlaylistMetaInformation(User user, String playlistCode) {
-        Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
         List<User> userList = userQueryService.getUserListByPlaylistCode(playlistCode);
 
@@ -77,7 +68,7 @@ public class PlaylistQueryService {
 
     @Transactional(readOnly = true)
     public PlaylistDetailResponseDTO getPlaylistDetail(User user, String playlistCode) {
-        Playlist playlist = getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
 
         List<VideoDetailResponseDTO> videoResponseList = videoQueryService.getVideoDetailListByPlaylistCode(
@@ -98,7 +89,8 @@ public class PlaylistQueryService {
 
     @Transactional(readOnly = true)
     public PlaylistHealthResponseDTO checkPlaylistHealth(String playlistCode) {
-        Optional<Playlist> playlistOptional = getPlaylistByCodeOptional(playlistCode);
+        Optional<Playlist> playlistOptional = playlistRepositoryService.findByCodeOptional(
+            playlistCode);
 
         // 플레이리스트가 존재하지 않는 경우
         if (playlistOptional.isEmpty()) {

--- a/src/main/java/com/uhsadong/ddtube/domain/service/UserCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/UserCommandService.java
@@ -5,6 +5,7 @@ import com.uhsadong.ddtube.domain.dto.response.CreateUserResponseDTO;
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.repository.UserRepository;
+import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
 import com.uhsadong.ddtube.global.util.IdGenerator;
@@ -21,7 +22,7 @@ import org.springframework.stereotype.Service;
 public class UserCommandService {
 
     private final UserRepository userRepository;
-    private final PlaylistQueryService playlistQueryService;
+    private final PlaylistRepositoryService playlistRepositoryService;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     @Value("${ddtube.user.code_length}")
@@ -71,7 +72,7 @@ public class UserCommandService {
      * 사용자 데이터가 존재하지 않을 때에는 회원가입을 시도한다.
      */
     private CreateUserResponseDTO signUp(String playlistCode, CreateUserRequestDTO requestDTO) {
-        Playlist playlist = playlistQueryService.getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         String code = IdGenerator.generateShortId(USER_CODE_LENGTH);
         User user = userRepository.save(
             User.toEntity(playlist, code, requestDTO.name(),

--- a/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/VideoCommandService.java
@@ -6,6 +6,7 @@ import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.entity.Video;
 import com.uhsadong.ddtube.domain.repository.VideoRepository;
+import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
 import com.uhsadong.ddtube.global.sse.SseService;
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class VideoCommandService {
 
     private final VideoRepository videoRepository;
-    private final PlaylistQueryService playlistQueryService;
+    private final PlaylistRepositoryService playlistRepositoryService;
     private final UserQueryService userQueryService;
     private final SseService sseService;
     @Value("${ddtube.video.code_length}")
@@ -35,7 +36,7 @@ public class VideoCommandService {
     @Transactional
     public void addVideoToPlaylist(
         User user, String playlistCode, AddVideoToPlaylistRequestDTO requestDTO) {
-        Playlist playlist = playlistQueryService.getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
 
         String code = IdGenerator.generateShortId(VIDEO_CODE_LENGTH);
@@ -56,7 +57,7 @@ public class VideoCommandService {
     @Transactional
     public void deleteVideoFromPlaylist(
         User user, String playlistCode, String videoCode) {
-        Playlist playlist = playlistQueryService.getPlaylistByCodeOrThrow(playlistCode);
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         userQueryService.checkUserInPlaylist(user, playlist);
         Video video = videoRepository.findFirstByPlaylistCodeAndCode(playlist.getCode(), videoCode)
             .orElseThrow(() -> new GeneralException(ErrorStatus._VIDEO_NOT_FOUND));

--- a/src/main/java/com/uhsadong/ddtube/global/scheduler/SseSchedulerController.java
+++ b/src/main/java/com/uhsadong/ddtube/global/scheduler/SseSchedulerController.java
@@ -1,21 +1,28 @@
 package com.uhsadong.ddtube.global.scheduler;
 
+import com.uhsadong.ddtube.domain.service.PlaylistCommandService;
 import com.uhsadong.ddtube.global.sse.SseService;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SseSchedulerController {
 
 
     private final SseService sseService;
+    private final PlaylistCommandService playlistCommandService;
 
 
     @Scheduled(fixedDelay = 60 * 1000) // 함수 종료 후 1분
     public void sendSsePingScheduler() {
-        sseService.sendPingWithConnectionCount();
+        Set<String> playlistCodeSet = sseService.sendPingWithConnectionCount();
+        int updateCount = playlistCommandService.updatePlaylistLastLoginAt(playlistCodeSet);
+        log.info("[    SCHED] Active Playlist Count {} | Ping Send", updateCount);
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/global/scheduler/SseSchedulerController.java
+++ b/src/main/java/com/uhsadong/ddtube/global/scheduler/SseSchedulerController.java
@@ -2,7 +2,6 @@ package com.uhsadong.ddtube.global.scheduler;
 
 import com.uhsadong.ddtube.domain.service.PlaylistCommandService;
 import com.uhsadong.ddtube.global.sse.SseService;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -20,9 +19,7 @@ public class SseSchedulerController {
 
     @Scheduled(fixedDelay = 60 * 1000) // 함수 종료 후 1분
     public void sendSsePingScheduler() {
-        Set<String> playlistCodeSet = sseService.sendPingWithConnectionCount();
-        int updateCount = playlistCommandService.updatePlaylistLastLoginAt(playlistCodeSet);
-        log.info("[    SCHED] Active Playlist Count {} | Ping Send", updateCount);
+        sseService.sendPingWithConnectionCount();
     }
 
 }


### PR DESCRIPTION
클래스 순환 참조 문제가 생겨서, RepositoryService로 한 단계 더 분리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 플레이리스트의 마지막 로그인 시간을 관리하는 기능이 추가되었습니다.

- **리팩터**
  - 플레이리스트 관련 서비스 구조가 개선되어, 여러 서비스에서 플레이리스트 조회 및 갱신이 일관되게 처리됩니다.
  - 기존에 직접적으로 사용하던 저장소(Repository) 의존성이 서비스 레이어로 대체되었습니다.

- **기타**
  - 일부 불필요한 import 및 주석이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->