### PR TITLE
[USD-87] 영상 순서 변경 기능 구현

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -9,6 +9,7 @@ import com.uhsadong.ddtube.domain.dto.response.PlaylistPublicMetaResponseDTO;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.service.PlaylistCommandService;
 import com.uhsadong.ddtube.domain.service.PlaylistQueryService;
+import com.uhsadong.ddtube.domain.service.VideoCommandService;
 import com.uhsadong.ddtube.global.response.ApiResponse;
 import com.uhsadong.ddtube.global.security.CurrentUser;
 import com.uhsadong.ddtube.global.util.S3Util;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,6 +37,7 @@ public class PlaylistController {
     private final PlaylistCommandService playlistCommandService;
     private final S3Util s3Util;
     private final PlaylistQueryService playlistQueryService;
+    private final VideoCommandService videoCommandService;
 
     @GetMapping("/{playlistCode}/health")
     @Operation(summary = "재생목록 상태 확인", description = "재생목록 상태 확인 기능입니다.")

--- a/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
@@ -1,6 +1,7 @@
 package com.uhsadong.ddtube.domain.controller;
 
 import com.uhsadong.ddtube.domain.dto.request.AddVideoToPlaylistRequestDTO;
+import com.uhsadong.ddtube.domain.dto.response.MoveVideoResponseDTO;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.service.VideoCommandService;
 import com.uhsadong.ddtube.global.response.ApiResponse;
@@ -10,10 +11,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,6 +46,21 @@ public class VideoController {
     ) {
         videoCommandService.deleteVideoFromPlaylist(user, playlistCode, videoCode);
         return ResponseEntity.ok(ApiResponse.onSuccess(playlistCode));
+    }
+
+    @PatchMapping("/{playlistCode}/{videoCode}/priority")
+    @Operation(summary = "재생목록 영상 우선순위 변경", description = "재생목록 영상 우선순위 변경 기능입니다. \n어떤 플레이리스트(playlistCode)에, \n어떤 영상(videoCode)을 \n어떤 영상(targetVideoCode)의 \n전후(positionBefore)로 이동시킬지 결정")
+    public ResponseEntity<ApiResponse<MoveVideoResponseDTO>> updateVideoPriority(
+        @CurrentUser User user,
+        @PathVariable String playlistCode,
+        @PathVariable String videoCode,
+        @RequestParam String targetVideoCode,
+        @RequestParam Boolean positionBefore
+    ) {
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+            videoCommandService.moveVideo(user, playlistCode, videoCode, targetVideoCode,
+                positionBefore)));
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/VideoController.java
@@ -9,6 +9,7 @@ import com.uhsadong.ddtube.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;

--- a/src/main/java/com/uhsadong/ddtube/domain/dto/response/MoveVideoResponseDTO.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/dto/response/MoveVideoResponseDTO.java
@@ -1,0 +1,13 @@
+package com.uhsadong.ddtube.domain.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MoveVideoResponseDTO (
+    boolean conflict,
+    String videoCode,
+    Long newPriority,
+    Long oldPriority
+) {
+
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/entity/Video.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/entity/Video.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -51,6 +52,8 @@ public class Video {
 
     @Positive
     private Long priority; // 재생목록 내 순서
+    @Version
+    private Long version; // 낙관적 락
 
     @Length(max = 255)
     @Column(nullable = false, length = 255)
@@ -91,6 +94,10 @@ public class Video {
             .thumbnailHeight(Integer.valueOf(youtubeInfo.thumbnail_height()))
             .thumbnailWidth(Integer.valueOf(youtubeInfo.thumbnail_width()))
             .build();
+    }
+
+    public void updatePriority(Long priority) {
+        this.priority = priority;
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/repository/VideoRepository.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/repository/VideoRepository.java
@@ -4,10 +4,14 @@ import com.uhsadong.ddtube.domain.entity.Video;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VideoRepository extends JpaRepository<Video, Long> {
+
     // Playlist Code와 Video Code로 Video를 찾는다.
     Optional<Video> findFirstByPlaylistCodeAndCode(String playlistCode, String code);
+
     // Playlist Code로 Video를 찾고 CreatedAt으로 정렬한다.
     List<Video> findAllByPlaylistCodeOrderByPriority(String playlistCode);
 
@@ -15,4 +19,51 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
     Optional<Video> findFirstByPlaylistCodeOrderByPriorityDesc(String playlistCode);
 
     Optional<Video> findFirstByCode(String code);
+
+    // 특정 우선순위보다 작고 특정 코드가 아닌 비디오 중 가장 우선순위가 큰 비디오
+    @Query("SELECT v "
+        + "FROM Video v "
+        + "WHERE v.playlist.code = :playlistCode "
+        + "AND v.priority < :priority "
+        + "AND v.code != :excludeVideoCode "
+        + "ORDER BY v.priority DESC "
+        + "LIMIT 1")
+    Optional<Video> findPreviousVideoExcept(
+        @Param("playlistCode") String playlistCode,
+        @Param("priority") Long priority,
+        @Param("excludeVideoCode") String excludeVideoCode);
+
+    // 특정 우선순위보다 크고 특정 코드가 아닌 비디오 중 가장 우선순위가 작은 비디오
+    @Query("SELECT v "
+        + "FROM Video v "
+        + "WHERE v.playlist.code = :playlistCode "
+        + "AND v.priority > :priority "
+        + "AND v.code != :excludeVideoCode "
+        + "ORDER BY v.priority ASC "
+        + "LIMIT 1")
+    Optional<Video> findNextVideoExcept(
+        @Param("playlistCode") String playlistCode,
+        @Param("priority") Long priority,
+        @Param("excludeVideoCode") String excludeVideoCode);
+
+
+    /**
+     * 특정 재생목록에서 지정된 우선순위를 가진 비디오가 있는지 확인합니다. (현재 이동 중인 비디오는 제외)
+     *
+     * @param playlistCode     재생목록 코드
+     * @param priority         확인할 우선순위 값
+     * @param excludeVideoCode 제외할 비디오 코드 (현재 이동 중인 비디오)
+     * @return 해당 우선순위를 가진 비디오가 있으면 true, 없으면 false
+     */
+    @Query("SELECT CASE "
+        + "WHEN COUNT(v) > 0 "
+        + "THEN true ELSE false END "
+        + "FROM Video v "
+        + "WHERE v.playlist.code = :playlistCode "
+        + "AND v.priority = :priority "
+        + "AND v.code != :excludeVideoCode")
+    boolean existsByPlaylistCodeAndPriorityAndCodeNot(
+        @Param("playlistCode") String playlistCode,
+        @Param("priority") Long priority,
+        @Param("excludeVideoCode") String excludeVideoCode);
 }

--- a/src/main/java/com/uhsadong/ddtube/global/config/WebMvcConfig.java
+++ b/src/main/java/com/uhsadong/ddtube/global/config/WebMvcConfig.java
@@ -30,7 +30,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOriginPatterns("*") // 허용할 출처 : 특정 도메인만 받을 수 있음
-            .allowedMethods("GET", "POST", "PUT", "DELETE") // 허용할 HTTP method
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH") // 허용할 HTTP method
             .allowCredentials(true); // 쿠키 인증 요청 허용
     }
 

--- a/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER002", "해당 사용자를 찾을 수 없습니다."),
     _CREATOR_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER003", "해당 플레이리스트의 생성자를 찾을 수 없습니다."),
     _USER_NOT_IN_PLAYLIST(HttpStatus.BAD_REQUEST, "USER004", "해당 사용자는 해당 플레이리스트에 속해있지 않습니다."),
+    _USER_NOT_ADMIN(HttpStatus.BAD_REQUEST, "USER005", "해당 사용자는 관리자 권한이 없습니다."),
 
     // VIDEO
     _VIDEO_NOT_FOUND(HttpStatus.BAD_REQUEST, "VIDEO001", "해당 비디오를 찾을 수 없습니다."),
@@ -48,6 +49,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _VIDEO_NOT_IN_PLAYLIST(HttpStatus.BAD_REQUEST, "VIDEO003", "해당 비디오는 해당 플레이리스트에 속해있지 않습니다."),
     _CANNOT_DELETE_NOW_PLAY_VIDEO(HttpStatus.BAD_REQUEST, "VIDEO004", "현재 재생중인 비디오는 삭제할 수 없습니다."),
     _VIDEO_MOVE_CONFLICT(HttpStatus.BAD_REQUEST, "VIDEO005", "비디오 이동 중 충돌이 발생했습니다."),
+    _TARGET_VIDEO_IS_SAME(HttpStatus.BAD_REQUEST, "VIDEO006", "같은 비디오입니다."),
 
     // YOUTUBE
     _YOUTUBE_OEMBED_BAD_REQUEST(HttpStatus.BAD_REQUEST, "YOUTUBE001", "가져올 수 없는 영상입니다."),

--- a/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _VIDEO_DELETE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "VIDEO002", "해당 비디오를 삭제할 권한이 없습니다."),
     _VIDEO_NOT_IN_PLAYLIST(HttpStatus.BAD_REQUEST, "VIDEO003", "해당 비디오는 해당 플레이리스트에 속해있지 않습니다."),
     _CANNOT_DELETE_NOW_PLAY_VIDEO(HttpStatus.BAD_REQUEST, "VIDEO004", "현재 재생중인 비디오는 삭제할 수 없습니다."),
+    _VIDEO_MOVE_CONFLICT(HttpStatus.BAD_REQUEST, "VIDEO005", "비디오 이동 중 충돌이 발생했습니다."),
 
     // YOUTUBE
     _YOUTUBE_OEMBED_BAD_REQUEST(HttpStatus.BAD_REQUEST, "YOUTUBE001", "가져올 수 없는 영상입니다."),


### PR DESCRIPTION
기존에 커밋으로만 반영했던 것을 PR로 다시 올립니다.

- Priority 재졍렬 기능은 근시일내에 구현할 계획입니다. 기본 Step이 100,000,000,000,000이기 때문에 46번을 넘기는 연속 이동이 없는 한 priority로 발생하는 문제는 없을 것입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 플레이리스트 내에서 비디오의 순서를 PATCH 요청으로 변경할 수 있는 기능이 추가되었습니다.
    - 비디오 이동 시 새로운 우선순위 정보를 반환하며, 이동 결과에 대한 상세 응답을 제공합니다.

- **버그 수정**
    - CORS 설정에 PATCH 메서드가 허용되어 다양한 클라이언트에서 PATCH 요청이 가능합니다.

- **기타**
    - 비디오 이동 시 충돌이 발생할 경우를 위한 새로운 에러 코드가 추가되었습니다.
    - 동시성 문제를 방지하기 위해 비디오 엔티티에 버전 관리가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->