### PR TITLE
[USD-118] feat: 펑 터진 플리 복구 기능 구현

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -122,4 +122,14 @@ public class PlaylistController {
         playlistCommandService.setNowPlayingVideo(user, playlistCode, videoCode, autoPlay);
         return ResponseEntity.ok(ApiResponse.onSuccess("변경 완료"));
     }
+
+    @PatchMapping("/{playlistCode}/restore")
+    @Operation(summary = "펑 터진 플레이리스트를 복구합니다. 추후에 이 과정 사이에 Ads를 넣으면 좋을 것 같습니다.")
+    public ResponseEntity<ApiResponse<String>> restorePlaylist(
+        @CurrentUser User user,
+        @PathVariable String playlistCode
+    ) {
+        playlistCommandService.restorePlaylist(user, playlistCode);
+        return ResponseEntity.ok(ApiResponse.onSuccess("복구 완료"));
+    }
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -5,6 +5,7 @@ import com.uhsadong.ddtube.domain.dto.response.CreatePlaylistResponseDTO;
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.entity.Video;
+import com.uhsadong.ddtube.domain.repository.PlaylistRepository;
 import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
 import com.uhsadong.ddtube.domain.validator.PlaylistValidator;
 import com.uhsadong.ddtube.domain.validator.UserValidator;
@@ -26,6 +27,7 @@ public class PlaylistCommandService {
     private final PlaylistRepositoryService playlistRepositoryService;
     private final PlaylistValidator playlistValidator;
     private final UserValidator userValidator;
+    private final PlaylistRepository playlistRepository;
 
     @Value("${ddtube.playlist.code_length}")
     private Integer PLAYLIST_CODE_LENGTH;
@@ -91,6 +93,15 @@ public class PlaylistCommandService {
 
         sseService.sendNowPlayingVideoEventToClients(playlistCode, video, user.getName(), autoPlay);
 
+    }
+
+    @Transactional
+    public void restorePlaylist(User user, String playlistCode) {
+        Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
+        // 플리가 비활성 상태인지 확인
+        playlistValidator.checkPlaylistIsInactive(playlist);
+        userValidator.checkUserInPlaylist(playlist, user);
+        playlistRepository.updateLastLoginAtByPlaylistCode(playlistCode, LocalDateTime.now());
     }
 
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistQueryService.java
@@ -9,14 +9,13 @@ import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.User;
 import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
 import com.uhsadong.ddtube.domain.repositoryservice.PlaylistRepositoryService;
+import com.uhsadong.ddtube.domain.utils.PlaylistUtil;
 import com.uhsadong.ddtube.domain.validator.UserValidator;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +28,6 @@ public class PlaylistQueryService {
     private final VideoQueryService videoQueryService;
     private final UserValidator userValidator;
 
-    @Value("${ddtube.playlist.delete_days}")
-    private Integer PLAYLIST_DELETE_DAYS;
 
     @Transactional(readOnly = true)
     public PlaylistPublicMetaResponseDTO getPlaylistPublicMetaInformation(String playlistCode) {
@@ -103,17 +100,7 @@ public class PlaylistQueryService {
         }
 
         // 플레이리스트가 존재하는 경우
-        Playlist playlist = playlistOptional.get();
-        PlaylistHealth health;
-
-        // 마지막으로 활성화된 시간 기준으로 PLAYLIST_DELETE_DAYS가 지났으면 INACTIVE 상태
-        if (playlist.getLastLoginAt().plusDays(PLAYLIST_DELETE_DAYS)
-            .isBefore(LocalDateTime.now())) {
-            health = PlaylistHealth.INACTIVE;
-        } else {
-            // 그 외의 경우 ACTIVE 상태
-            health = PlaylistHealth.ACTIVE;
-        }
+        PlaylistHealth health = PlaylistUtil.getPlaylistHealth(playlistOptional.get());
 
         return PlaylistHealthResponseDTO.builder()
             .health(health)

--- a/src/main/java/com/uhsadong/ddtube/domain/utils/PlaylistUtil.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/utils/PlaylistUtil.java
@@ -1,0 +1,22 @@
+package com.uhsadong.ddtube.domain.utils;
+
+import com.uhsadong.ddtube.domain.entity.Playlist;
+import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class PlaylistUtil {
+
+    public static PlaylistHealth getPlaylistHealth(Playlist playlist) {
+        int playlistDeleteDays = 1;
+        // 마지막으로 활성화된 시간 기준으로 PLAYLIST_DELETE_DAYS가 지났으면 INACTIVE 상태
+        if (Objects.isNull(playlist)){
+            return PlaylistHealth.NOT_EXIST;
+        }
+        else if (playlist.getLastLoginAt().plusDays(playlistDeleteDays)
+            .isBefore(LocalDateTime.now())) {
+            return PlaylistHealth.INACTIVE;
+        }
+        return PlaylistHealth.ACTIVE;
+    }
+}

--- a/src/main/java/com/uhsadong/ddtube/domain/validator/PlaylistValidator.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/validator/PlaylistValidator.java
@@ -2,6 +2,8 @@ package com.uhsadong.ddtube.domain.validator;
 
 import com.uhsadong.ddtube.domain.entity.Playlist;
 import com.uhsadong.ddtube.domain.entity.Video;
+import com.uhsadong.ddtube.domain.enums.PlaylistHealth;
+import com.uhsadong.ddtube.domain.utils.PlaylistUtil;
 import com.uhsadong.ddtube.global.response.code.status.ErrorStatus;
 import com.uhsadong.ddtube.global.response.exception.GeneralException;
 import com.uhsadong.ddtube.global.util.S3Util;
@@ -27,6 +29,12 @@ public class PlaylistValidator {
     public void checkVideoInPlaylist(Playlist playlist, Video video) {
         if (!Objects.equals(playlist.getId(), video.getPlaylist().getId())) {
             throw new GeneralException(ErrorStatus._VIDEO_NOT_IN_PLAYLIST);
+        }
+    }
+
+    public void checkPlaylistIsInactive(Playlist playlist) {
+        if (PlaylistUtil.getPlaylistHealth(playlist) == PlaylistHealth.ACTIVE) {
+            throw new GeneralException(ErrorStatus._PLAYLIST_IS_ACTIVE);
         }
     }
 }

--- a/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/uhsadong/ddtube/global/response/code/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // PLAYLIST
     _PLAYLIST_NOT_FOUND(HttpStatus.BAD_REQUEST, "PLAYLIST001", "해당 플레이리스트를 찾을 수 없습니다."),
     _PLAYLIST_DELETE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "PLAYLIST002", "해당 플레이리스트를 삭제할 권한이 없습니다."),
+    _PLAYLIST_IS_ACTIVE(HttpStatus.BAD_REQUEST, "PLAYLIST003", "해당 플레이리스트는 활성화 상태입니다."),
 
     // USER
     _USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER001", "이미 존재하는 사용자이며, 비밀번호가 틀렸습니다."),

--- a/src/test/java/com/uhsadong/ddtube/service/PlaylistQueryServiceTest.java
+++ b/src/test/java/com/uhsadong/ddtube/service/PlaylistQueryServiceTest.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class PlaylistQueryServiceTest {
 
-    private final Integer deleteAfterDays = 30;
+    private final int deleteAfterDays = 1;
     @InjectMocks
     private PlaylistQueryService playlistQueryService;
     @Mock
@@ -46,10 +45,6 @@ class PlaylistQueryServiceTest {
     @Mock
     private UserValidator userValidator;
 
-    @BeforeEach
-    void setUp() {
-        ReflectionTestUtils.setField(playlistQueryService, "PLAYLIST_DELETE_DAYS", deleteAfterDays);
-    }
 
     @Test
     @DisplayName("플레이리스트 공개 메타 정보 조회 - 코드에 해당하는 플레이리스트의 기본 정보를 반환한다")


### PR DESCRIPTION
펑 터진 플리라면 복구할 수 있는 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자가 비활성화된(“고장난”) 플레이리스트를 복구할 수 있는 복구 엔드포인트가 추가되었습니다.
- **버그 수정**
    - 플레이리스트의 활성/비활성 상태 검증이 강화되어, 활성화된 플레이리스트는 복구할 수 없도록 개선되었습니다.
- **리팩터링**
    - 플레이리스트의 상태(health) 판단 로직이 별도의 유틸리티 클래스로 분리되어 관리됩니다.
- **테스트**
    - 플레이리스트 상태 관련 테스트 코드가 최신 로직에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->