### PR TITLE
[USD-118] feat: 플리 복구 유저 인증 제거 (기획상 변경)

### DIFF
--- a/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/controller/PlaylistController.java
@@ -126,10 +126,9 @@ public class PlaylistController {
     @PatchMapping("/{playlistCode}/restore")
     @Operation(summary = "펑 터진 플레이리스트를 복구합니다. 추후에 이 과정 사이에 Ads를 넣으면 좋을 것 같습니다.")
     public ResponseEntity<ApiResponse<String>> restorePlaylist(
-        @CurrentUser User user,
         @PathVariable String playlistCode
     ) {
-        playlistCommandService.restorePlaylist(user, playlistCode);
+        playlistCommandService.restorePlaylist(playlistCode);
         return ResponseEntity.ok(ApiResponse.onSuccess("복구 완료"));
     }
 }

--- a/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
+++ b/src/main/java/com/uhsadong/ddtube/domain/service/PlaylistCommandService.java
@@ -96,11 +96,10 @@ public class PlaylistCommandService {
     }
 
     @Transactional
-    public void restorePlaylist(User user, String playlistCode) {
+    public void restorePlaylist(String playlistCode) {
         Playlist playlist = playlistRepositoryService.findByCodeOrThrow(playlistCode);
         // 플리가 비활성 상태인지 확인
         playlistValidator.checkPlaylistIsInactive(playlist);
-        userValidator.checkUserInPlaylist(playlist, user);
         playlistRepository.updateLastLoginAtByPlaylistCode(playlistCode, LocalDateTime.now());
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 플레이리스트 복원 기능에서 사용자 인증 절차가 제거되어, 사용자 정보 없이도 플레이리스트 복원이 가능해졌습니다.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->